### PR TITLE
Remove unnecessary KaTeX JS

### DIFF
--- a/templates/main.html
+++ b/templates/main.html
@@ -7,9 +7,6 @@
     <link rel="stylesheet" href="${data.root}assets/highlight.css">
     <title>${data.attributes.title} @ Aidan's Website</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.css" integrity="sha384-AfEj0r4/OFrOo5t7NnNe46zW/tFgW6x/bCJG8FqQCEo3+Aro6EYUG4+cU+KJWu/X" crossorigin="anonymous">
-    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.js" integrity="sha384-g7c+Jr9ZivxKLnZTDUhnkOnsh30B4H0rpLUpJ4jAIKs4fnJI+sEnkvrMWph2EDg4" crossorigin="anonymous"></script>
-    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/contrib/auto-render.min.js" integrity="sha384-mll67QQFJfxn0IYznZYonOWZ644AWYC+Pt2cHqMaRhXVrursRwvLnLaebdGIlYNa" crossorigin="anonymous"
-        onload="renderMathInElement(document.body);"></script>
 </head>
 <body>
     <div id="content">


### PR DESCRIPTION
According to https://github.com/KaTeX/KaTeX/issues/2176, as you are rendering KaTeX in the site compiler code, it isn't actually necessary to include the KaTeX JS libraries in the page. Removing them should make the site mildly more efficient.